### PR TITLE
Add description for head-CelebAText-HQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A collection of resources on text-to-image synthesis task.
   * [Multi-Modal-CelebA-HQ](#head-Multi-Modal-CelebA-HQ)
   * [CelebA-Dialog](#head-CelebA-Dialog)
   * [FFHQ-Text](#head-FFHQ-Text)
+  * [CelebAText-HQ](#head-CelebAText-HQ)
 
 * - [ ] [4. Project](#head4)
 
@@ -128,6 +129,15 @@ A number of studies have been conducted on the text-to-image synthesis technique
     * Descriptions per image: 9 Captions
     * 13 multi-valued facial element groups from coarse to fine.
   * **Detailed information (BBox):** ⇒ [[Website](https://www.robots.ox.ac.uk/~vgg/software/via/)]
+
+
+* <span id="head-CelebAText-HQ "> **CelebAText-HQ** </span>
+
+ CelebAText-HQ is a large-scale face image dataset with large-scale facial attributes, designed for text-to-face generation.
+
+  * **Detailed information (Images & Text Descriptions):**  ⇒ [[Paper](https://dl.acm.org/doi/abs/10.1145/3474085.3475391)] [[Website](https://github.com/cripac-sjx/SEA-T2F)] [[Download](https://drive.google.com/drive/folders/1IAb_iy6-soEGQWhbgu6cQODsIUJZpahC)]
+    * Number of images (from Celeba-HQ): 15010 (**Training**: 13,710. **Testing**: 1300.)
+    * Descriptions per image: 10 Captions
 
 ## <span id="head4"> *4. Project* </span>
 * **Aphantasia**. [[Github](https://github.com/eps696/aphantasia)] 


### PR DESCRIPTION
Hello.

This PR adds description for `CelebAText-HQ`  (I am not the author).

This dataset is large, and has high quarity manual caption.

ref:
- [Paper](https://dl.acm.org/doi/abs/10.1145/3474085.3475391)
- [Website](https://github.com/cripac-sjx/SEA-T2F)


thank you in advance.