### PR TITLE
Add CasTex to "Text → 3D/Motion/Shape/Mesh/Object..." section

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,8 @@ A number of studies have been conducted on text-to-image synthesis techniques th
 
 [<u><🎯Back to Top></u>](#head-content)
  
-   * <span id="head-t2m"> **Text → 3D/Motion/Shape/Mesh/Object...** </span> 
+   * <span id="head-t2m"> **Text → 3D/Motion/Shape/Mesh/Object...** </span>
+      * (WACV 2026) [💬Text → Texture] **CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading**, Mishan Aliev et al. [[Paper](https://arxiv.org/abs/2504.06856)] [[Project](https://thecrazymage.github.io/CasTex/)]
        * (arXiv preprint 2024) [💬Text → Motion] **CrowdMoGen: Zero-Shot Text-Driven Collective Motion Generation**, Xinying Guo et al. [[Paper](https://arxiv.org/abs/2407.06188)] [[Project](https://gxyes.github.io/projects/CrowdMoGen.html)]
        * (ACMMM 2024) [💬Text → 3D] **PlacidDreamer: Advancing Harmony in Text-to-3D Generation**, Shuo Huang et al. [[Paper](https://arxiv.org/abs/2407.13976)] [[Code](https://github.com/HansenHuang0823/PlacidDreamer)]
        * (Meta) [💬Text → 3D] **Meta 3D Gen**, Raphael Bensadoun et al. [[Paper](https://scontent-dus1-1.xx.fbcdn.net/v/t39.2365-6/449707112_509645168082163_2193712134508658234_n.pdf?_nc_cat=111&ccb=1-7&_nc_sid=3c67a6&_nc_ohc=TdfUsn5eGzgQ7kNvgEir1_g&_nc_ht=scontent-dus1-1.xx&oh=00_AYCH-Fbi8CL2l3Yc3ehAr-Itl5B6Wbo7KtXeONb8KCJ_mg&oe=668C1291)]


### PR DESCRIPTION
Hello! I would like to add our accepted paper **CasTex** to the list.

**Paper:** CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading
**Authors:** Mishan Aliev, Dmitry Baranchuk, Kirill Struminsky
**Arxiv:** https://arxiv.org/abs/2504.06856 (Accepted WACV'2026)
**Project Page:** https://thecrazymage.github.io/CasTex/
**Code:** https://github.com/thecrazymage/CasTex/

**Why it fits:**
This work introduces a text-to-texture synthesis method that generates high-quality **PBR materials** (Albedo, Roughness, Metallic, Normal). Unlike previous optimization-based methods (like Paint-it or Fantasia3D) that rely on Latent Diffusion Models and suffer from oversaturation artifacts, CasTex employs **Score Distillation Sampling (SDS) in pixel space** using Cascaded Diffusion Models (DeepFloyd-IF). This approach eliminates the need for implicit regularization (DIP) and achieves state-of-the-art results on Objaverse benchmarks.
