### PR TITLE
Fix broken star history links

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ A number of studies have been conducted on text-to-image synthesis techniques th
 
 ## <span id="head7"> Contact Me </span>
 
- [![Star History Chart](https://api.star-history.com/svg?repos=Yutong-Zhou-cv/Awesome-Text-to-Image&type=Date)](https://star-history.com/#Yutong-Zhou-cv/Awesome-Text-to-Image&Date)
+ [![Star History](https://star-history.deno.page/svg?repos=Yutong-Zhou-cv/Awesome-Text-to-Image&type=Date)](https://star-history.deno.page/#Yutong-Zhou-cv/Awesome-Text-to-Image&Date)
 
 If you have any questions or comments, please feel free to contact [**Yutong**](https://elizazhou96.github.io/) ლ(╹◡╹ლ)
 


### PR DESCRIPTION
The stargazer chart link in README is broken due to GitHub API issues. This changes it to use the star-history.deno.page domain, which provides the same chart via a fork using a token-free data source.